### PR TITLE
Fix incorrect favicon src

### DIFF
--- a/version_control/katalyst_by_codurance/templates/layouts/base.html
+++ b/version_control/katalyst_by_codurance/templates/layouts/base.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="utf-8">
     {% if page_meta.html_title or pageTitle %}<title>{{ page_meta.html_title or pageTitle }}</title>{% endif %}
-    {% if brand_settings.primaryFavicon.src %}<link rel="shortcut icon" href="{{ brand_settings.primaryFavicon.src }}" />{% endif %}
+    {% if site_settings.favicon_src %}<link rel="shortcut icon" href="{{ site_settings.favicon_src }}" />{% endif %}
     <meta name="description" content="{{ page_meta.meta_description }}">
     {{ require_css(get_asset_url("../../css/main.css")) }}
     {{ require_css(get_asset_url("../../css/theme-overrides.css")) }}


### PR DESCRIPTION
The Katalyst favicon was being overrided by the default favicon on the Codurance website.